### PR TITLE
torch.eig deprecated

### DIFF
--- a/pyhessian/hessian.py
+++ b/pyhessian/hessian.py
@@ -258,7 +258,7 @@ class hessian():
                 if i < len(alpha_list) - 1:
                     T[i + 1, i] = beta_list[i]
                     T[i, i + 1] = beta_list[i]
-            a_, b_ = torch.eig(T, eigenvectors=True)
+            a_, b_ = torch.linalg.eig(T)
 
             eigen_list = a_[:, 0]
             weight_list = b_[0, :]**2

--- a/pyhessian/hessian.py
+++ b/pyhessian/hessian.py
@@ -260,8 +260,8 @@ class hessian():
                     T[i, i + 1] = beta_list[i]
             a_, b_ = torch.linalg.eig(T)
 
-            eigen_list = a_[:, 0]
-            weight_list = b_[0, :]**2
+            eigen_list = a_
+            weight_list = torch.pow(b_, 2)
             eigen_list_full.append(list(eigen_list.cpu().numpy()))
             weight_list_full.append(list(weight_list.cpu().numpy()))
 


### PR DESCRIPTION
Updated file to reflect deprecation of `torch.eig` as of torch 1.9 to use `torch.linalg.eig`

Note: the argument `eigenvectors=True` must also be removed as this no longer exists in the function signature